### PR TITLE
base frame timestamp off epicsTS

### DIFF
--- a/firewireWinApp/src/firewireWinDCAM.cpp
+++ b/firewireWinApp/src/firewireWinDCAM.cpp
@@ -464,7 +464,6 @@ void FirewireWinDCAM::imageGrabTask()
     int numImages, numImagesCounter;
     int imageMode;
     int arrayCallbacks;
-    epicsTimeStamp startTime;
     int acquire;
     const char *functionName = "imageGrabTask";
 
@@ -499,8 +498,6 @@ void FirewireWinDCAM::imageGrabTask()
             setIntegerParam(ADAcquire, 1);
         }
 
-        /* Get the current time */
-        epicsTimeGetCurrent(&startTime);
         /* We are now waiting for an image  */
         setIntegerParam(ADStatus, ADStatusWaiting);
         /* Call the callbacks to update any changes */
@@ -532,8 +529,8 @@ void FirewireWinDCAM::imageGrabTask()
         /* Put the frame number into the buffer */
         this->pRaw->uniqueId = imageCounter;
         /* Set a timestamp in the buffer */
-        this->pRaw->timeStamp = startTime.secPastEpoch + startTime.nsec / 1.e9;
         updateTimeStamp(&this->pRaw->epicsTS);
+        this->pRaw->timeStamp = this->pRaw->epicsTS.secPastEpoch + this->pRaw->epicsTS.nsec / 1.e9;
 
         /* Get any attributes that have been defined for this driver */        
         this->getAttributes(this->pRaw->pAttributeList);

--- a/firewireWinApp/src/firewireWinDCAM.cpp
+++ b/firewireWinApp/src/firewireWinDCAM.cpp
@@ -529,8 +529,7 @@ void FirewireWinDCAM::imageGrabTask()
         /* Put the frame number into the buffer */
         this->pRaw->uniqueId = imageCounter;
         /* Set a timestamp in the buffer */
-        updateTimeStamp(&this->pRaw->epicsTS);
-        this->pRaw->timeStamp = this->pRaw->epicsTS.secPastEpoch + this->pRaw->epicsTS.nsec / 1.e9;
+        updateTimeStamp(this->pRaw);
 
         /* Get any attributes that have been defined for this driver */        
         this->getAttributes(this->pRaw->pAttributeList);

--- a/firewireWinApp/src/firewireWinDCAM.cpp
+++ b/firewireWinApp/src/firewireWinDCAM.cpp
@@ -529,7 +529,7 @@ void FirewireWinDCAM::imageGrabTask()
         /* Put the frame number into the buffer */
         this->pRaw->uniqueId = imageCounter;
         /* Set a timestamp in the buffer */
-        updateTimeStamp(this->pRaw);
+        updateTimeStamps(this->pRaw);
 
         /* Get any attributes that have been defined for this driver */        
         this->getAttributes(this->pRaw->pAttributeList);


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.